### PR TITLE
patch for issue 5: prevent database null values being read into EntityProfile objects 

### DIFF
--- a/jedai-core/src/main/java/org/scify/jedai/datareader/entityreader/EntityDBReader.java
+++ b/jedai-core/src/main/java/org/scify/jedai/datareader/entityreader/EntityDBReader.java
@@ -119,7 +119,9 @@ public class EntityDBReader extends AbstractEntityReader {
                     }
 
                     final String value = rs.getString(columns[i]);
-                    newProfile.addAttribute(attributeName, value);
+                    if (!rs.wasNull()) {
+                      newProfile.addAttribute(attributeName, value);
+                    }
                 }
             }
             rs.close();


### PR DESCRIPTION
Added null check to  EntityDBReader.getEntityProfiles()