### PR TITLE
Fix loss of numeric precision 

### DIFF
--- a/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/AbstractMetablocking.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/AbstractMetablocking.java
@@ -1,37 +1,35 @@
 /*
-* Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.scify.jedai.blockprocessing.comparisoncleaning;
-
-import org.scify.jedai.datamodel.AbstractBlock;
-import org.scify.jedai.datamodel.BilateralBlock;
-import org.scify.jedai.datamodel.Comparison;
-import org.scify.jedai.datamodel.UnilateralBlock;
-import org.scify.jedai.utilities.enumerations.WeightingScheme;
 
 import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
-
-import java.util.List;
-
 import org.apache.commons.math3.stat.inference.ChiSquareTest;
 import org.apache.jena.atlas.json.JsonArray;
 import org.apache.jena.atlas.json.JsonObject;
+import org.scify.jedai.datamodel.AbstractBlock;
+import org.scify.jedai.datamodel.BilateralBlock;
+import org.scify.jedai.datamodel.Comparison;
+import org.scify.jedai.datamodel.UnilateralBlock;
 import org.scify.jedai.utilities.IConstants;
+import org.scify.jedai.utilities.enumerations.WeightingScheme;
+
+import java.util.List;
 
 /**
  *
@@ -54,7 +52,7 @@ public abstract class AbstractMetablocking extends AbstractComparisonCleaning im
     protected final TIntList retainedNeighbors;
     protected final TIntList retainedNeighborsWeights;
     protected WeightingScheme weightingScheme;
-    
+
     public AbstractMetablocking(WeightingScheme wScheme) {
         super();
         neighbors = new TIntArrayList();
@@ -96,7 +94,7 @@ public abstract class AbstractMetablocking extends AbstractComparisonCleaning im
     protected int discretizeComparisonWeight(double weight) {
         return (int) (weight * DISCRETIZATION_FACTOR);
     }
-    
+
     protected Comparison getComparison(int entityId, int neighborId) {
         if (!cleanCleanER) {
             if (entityId < neighborId) {
@@ -173,7 +171,7 @@ public abstract class AbstractMetablocking extends AbstractComparisonCleaning im
             case CBS:
                 return counters[neighborId];
             case ECBS:
-                return counters[neighborId] * Math.log10(noOfBlocks / entityIndex.getNoOfEntityBlocks(entityId, 0)) * Math.log10(noOfBlocks / entityIndex.getNoOfEntityBlocks(neighborId, 0));
+                return counters[neighborId] * Math.log10((double) noOfBlocks / entityIndex.getNoOfEntityBlocks(entityId, 0)) * Math.log10((double) noOfBlocks / entityIndex.getNoOfEntityBlocks(neighborId, 0));
             case JS:
                 return counters[neighborId] / (entityIndex.getNoOfEntityBlocks(entityId, 0) + entityIndex.getNoOfEntityBlocks(neighborId, 0) - counters[neighborId]);
             case EJS:

--- a/src/main/java/org/scify/jedai/progressivejoin/JaccardTopK.java
+++ b/src/main/java/org/scify/jedai/progressivejoin/JaccardTopK.java
@@ -1,17 +1,17 @@
 /*
-* Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.scify.jedai.progressivejoin;
 
@@ -74,7 +74,7 @@ public class JaccardTopK {
     }
 
     public double upperbound_access_internal(int probe, int ind) {
-        return probe * ind / (probe + ind - probe * ind);
+        return (double) probe * ind / (probe + ind - probe * ind);
     }
 
     public double upperbound_index(int len1, int pos) {

--- a/src/main/java/org/scify/jedai/similarityjoins/characterbased/AllPairs.java
+++ b/src/main/java/org/scify/jedai/similarityjoins/characterbased/AllPairs.java
@@ -1,17 +1,17 @@
 /*
-* Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.scify.jedai.similarityjoins.characterbased;
 
@@ -94,7 +94,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
     public String getMethodName() {
         return "Character-based All Pairs";
     }
-    
+
     @Override
     public String getMethodParameters() {
         return getMethodName() + " involves two parameters:\n"
@@ -124,7 +124,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
         }
         return result;
     }
-    
+
     @Override
     public String getParameterDescription(int parameterId) {
         switch (parameterId) {
@@ -138,7 +138,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
                 return "invalid parameter id";
         }
     }
-    
+
     @Override
     public String getParameterName(int parameterId) {
         switch (parameterId) {
@@ -150,7 +150,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
                 return "invalid parameter id";
         }
     }
-    
+
     private void getTokens(int rangeBound) {
         final TIntIntMap freqMap = new TIntIntHashMap();
         for (int k = rangeBound; k < noOfEntities; k++) {
@@ -164,7 +164,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
         }
 
         final List<IntPair> packages = new ArrayList<>();
-        for (TIntIntIterator iterator = freqMap.iterator(); iterator.hasNext();) {
+        for (TIntIntIterator iterator = freqMap.iterator(); iterator.hasNext(); ) {
             iterator.advance();
             packages.add(new IntPair(iterator.key(), iterator.value()));
         }
@@ -236,7 +236,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
 
         return rangeBound;
     }
-    
+
     private List<Comparison> performJoin(int rangeBound) {
         final List<Comparison> executedComparisons = new ArrayList<>();
         for (int x = 0; x < rangeBound; x++) {
@@ -252,7 +252,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
                 int distance = getEditDistance(attributeValues.get(x), attributeValues.get(y), threshold);
                 if (distance <= threshold) {
                     final Comparison currentComp = getComparison(originalId[x], originalId[y]);
-                    currentComp.setUtilityMeasure(1 - distance / threshold);
+                    currentComp.setUtilityMeasure(1 - (double) distance / threshold);
                     executedComparisons.add(currentComp);
                 }
             }
@@ -263,7 +263,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
             int lastToken = -1;
 
             final TIntSet occurances = new TIntHashSet();
-            for (TIntIterator iter = tokens[k].iterator(); iter.hasNext();) {
+            for (TIntIterator iter = tokens[k].iterator(); iter.hasNext(); ) {
                 int token = iter.next();
                 if (count++ >= threshold * q + 1) {
                     break;
@@ -297,7 +297,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
                 index.put(token, item);
             }
 
-            for (TIntIterator setIterator = occurances.iterator(); setIterator.hasNext();) {
+            for (TIntIterator setIterator = occurances.iterator(); setIterator.hasNext(); ) {
                 int cand = setIterator.next();
                 if (isCleanCleanER) {
                     if (originalId[k] < datasetDelimiter && originalId[cand] < datasetDelimiter) { // both belong to dataset 1
@@ -366,7 +366,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
         }
         return executedComparisons;
     }
-    
+
     @Override
     public void setNextRandomConfiguration() {
         super.setNextRandomConfiguration();
@@ -377,7 +377,7 @@ public class AllPairs extends AbstractCharacterBasedJoin {
     public void setNumberedGridConfiguration(int iterationNumber) {
         int ngSizeIteration = iterationNumber / gridThreshold.getNumberOfConfigurations();
         q = (Integer) gridNGSize.getNumberedValue(ngSizeIteration);
-        
+
         int thrIteration = iterationNumber - ngSizeIteration * gridThreshold.getNumberOfConfigurations();
         threshold = (Integer) gridThreshold.getNumberedValue(thrIteration);
     }

--- a/src/main/java/org/scify/jedai/similarityjoins/characterbased/EdJoin.java
+++ b/src/main/java/org/scify/jedai/similarityjoins/characterbased/EdJoin.java
@@ -1,17 +1,17 @@
 /*
-* Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.scify.jedai.similarityjoins.characterbased;
 
@@ -110,7 +110,7 @@ public class EdJoin extends AbstractCharacterBasedJoin {
         }
 
         final List<IntPair> packages = new ArrayList<>();
-        for (TIntIntIterator iterator = freqMap.iterator(); iterator.hasNext();) {
+        for (TIntIntIterator iterator = freqMap.iterator(); iterator.hasNext(); ) {
             iterator.advance();
             packages.add(new IntPair(iterator.key(), iterator.value()));
         }
@@ -224,7 +224,7 @@ public class EdJoin extends AbstractCharacterBasedJoin {
                 int distance = getEditDistance(attributeValues.get(x), attributeValues.get(y), threshold);
                 if (distance <= threshold) {
                     final Comparison currentComp = getComparison(originalId[x], originalId[y]);
-                    currentComp.setUtilityMeasure(1 - distance / threshold);
+                    currentComp.setUtilityMeasure(1 - (double) distance / threshold);
                     executedComparisons.add(currentComp);
                 }
             }
@@ -267,7 +267,7 @@ public class EdJoin extends AbstractCharacterBasedJoin {
                 index.put(token.getValue(), item);
             }
 
-            for (TIntIterator setIterator = occurances.iterator(); setIterator.hasNext();) {
+            for (TIntIterator setIterator = occurances.iterator(); setIterator.hasNext(); ) {
                 int cand = setIterator.next();
                 if (isCleanCleanER) {
                     if (originalId[k] < datasetDelimiter && originalId[cand] < datasetDelimiter) { // both belong to dataset 1

--- a/src/main/java/org/scify/jedai/similarityjoins/characterbased/FastSS.java
+++ b/src/main/java/org/scify/jedai/similarityjoins/characterbased/FastSS.java
@@ -1,17 +1,17 @@
 /*
-* Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright [2016-2020] [George Papadakis (gpapadis@yahoo.gr)]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.scify.jedai.similarityjoins.characterbased;
 
@@ -19,14 +19,14 @@ import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.set.TIntSet;
 import gnu.trove.set.hash.TIntHashSet;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
 import org.scify.jedai.datamodel.Comparison;
-
 import org.scify.jedai.datamodel.EntityProfile;
 import org.scify.jedai.datamodel.SimilarityPairs;
 import org.scify.jedai.datamodel.joins.IntListPair;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 
 /**
  *
@@ -116,7 +116,7 @@ public class FastSS extends AbstractCharacterBasedJoin {
             if (ed <= threshold) {
                 checkedFlag.add(p.getKey());
                 final Comparison currentComp = getComparison(id, p.getKey());
-                currentComp.setUtilityMeasure(1 - ed / threshold);
+                currentComp.setUtilityMeasure(1 - (double) ed / threshold);
                 executedComparisons.add(currentComp);
             }
         }


### PR DESCRIPTION
Loss of precision from int / int as the result is an int.
Cast int to double before numeric operations to produce double result type.

For example:
`1 - ed / threshold` will result in an integer (truncated)
`1 - (double) ed / threshold` will result in a double