### PR TITLE
Replace non-maven central dependency with maven central version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,10 +62,11 @@
             <version>3.0.3</version>
         </dependency>
 
+        <!-- https://mvnrepository.com/artifact/com.esotericsoftware/minlog -->
         <dependency>
-            <groupId>com.esotericsoftware.minlog</groupId>
+            <groupId>com.esotericsoftware</groupId>
             <artifactId>minlog</artifactId>
-            <version>1.2-slf4j-jdanbrown-0</version>
+            <version>1.3.1</version>
         </dependency>
 
         <dependency>
@@ -129,13 +130,6 @@
         </dependency>
 
     </dependencies>
-
-    <repositories>
-        <repository>
-            <id>premise</id>
-            <url>http://premise.artifactoryonline.com/premise/public</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>


### PR DESCRIPTION
This PR removes a repository in the pom file as the dependency it provides already exists in maven central.

This also fixes problems resolving the dependency in some maven versions
