### PR TITLE
Allow snapshots and improved pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.scify</groupId>
-    <version>3.0</version>
+    <version>3.0-SNAPSHOT</version>
     <artifactId>jedai-core</artifactId>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -34,11 +34,10 @@
     </scm>
 
     <distributionManagement>
-        <repository>
+        <snapshotRepository>
             <id>sonatype-nexus-staging</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <packaging>jar</packaging>
@@ -134,14 +133,25 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>sonatype-nexus-staging</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
+                <version>3.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -154,7 +164,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.9.1</version>
+                <version>3.0.1</version>
                 <configuration>
                     <source>8</source>
                 </configuration>
@@ -168,8 +178,9 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
+                <version>3.2.0</version>
                 <configuration>
                     <archive>
                         <manifest>


### PR DESCRIPTION
Hi,

This PR does a few things.

1. I've added the nexus-staging-maven-plugin to the pom.xml, this will allow you to see the result of your deployment to _maven central release_ directly in your build console. Maven deploy plugin just doesn't cut it for OSSRH
2. I've added the snapshot repository to allow you to deploy snapshots, to do this just append "-SNAPSHOT" to the version
3. Updated the dependencies to a newer version

I've retain both
```
<serverId>sonatype-nexus-staging</serverId>
<id>sonatype-nexus-staging</id>
```

so you don't have to update the settings.xml in the ~/.m2 folder. Just run the same deploy command, everything should work as-is