### PR TITLE
Fixed CSVReader separating quoted text

### DIFF
--- a/src/main/java/org/scify/jedai/datareader/entityreader/EntityCSVReader.java
+++ b/src/main/java/org/scify/jedai/datareader/entityreader/EntityCSVReader.java
@@ -36,7 +36,7 @@ public class EntityCSVReader extends AbstractEntityReader {
 
     private boolean attributeNamesInFirstRow;
     private int idIndex;
-    private String separator;
+    private char separator;
     private String[] attributeNames;
     private final Set<Integer> attributesToExclude;
 
@@ -45,7 +45,7 @@ public class EntityCSVReader extends AbstractEntityReader {
         attributeNamesInFirstRow = false;
         attributeNames = null;
         idIndex = -1;
-        separator = ",";
+        separator = ',';
         attributesToExclude = new HashSet<>();
     }
 
@@ -61,7 +61,7 @@ public class EntityCSVReader extends AbstractEntityReader {
         }
 
         try (final BufferedReader br = new BufferedReader(new FileReader(inputFilePath));
-             final CSVReader csvReader = new CSVReader(br)) {
+             final CSVReader csvReader = new CSVReader(br, separator)) {
 
             // Get first line
             final String[] firstRecord = csvReader.readNext();
@@ -282,7 +282,7 @@ public class EntityCSVReader extends AbstractEntityReader {
         attributesToExclude.add(idIndex);
     }
 
-    public void setSeparator(String separator) {
+    public void setSeparator(char separator) {
         this.separator = separator;
     }
 }

--- a/src/main/java/org/scify/jedai/datareader/entityreader/EntityCSVReader.java
+++ b/src/main/java/org/scify/jedai/datareader/entityreader/EntityCSVReader.java
@@ -15,11 +15,13 @@
  */
 package org.scify.jedai.datareader.entityreader;
 
+import com.esotericsoftware.minlog.Log;
+import com.opencsv.CSVReader;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
 import org.scify.jedai.datamodel.EntityProfile;
 
-import com.esotericsoftware.minlog.Log;
 import java.io.BufferedReader;
-
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.Arrays;
@@ -27,15 +29,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.apache.jena.atlas.json.JsonArray;
-import org.apache.jena.atlas.json.JsonObject;
-
 /**
- *
  * @author G.A.P. II
  */
 public class EntityCSVReader extends AbstractEntityReader {
-    
+
     private boolean attributeNamesInFirstRow;
     private int idIndex;
     private String separator;
@@ -62,28 +60,27 @@ public class EntityCSVReader extends AbstractEntityReader {
             return null;
         }
 
-        try {
-            //creating reader
-            final BufferedReader br = new BufferedReader(new FileReader(inputFilePath));
+        try (final BufferedReader br = new BufferedReader(new FileReader(inputFilePath));
+             final CSVReader csvReader = new CSVReader(br)) {
 
-            //getting first line
-            String line = br.readLine();
-            if (line == null) {
+            // Get first line
+            final String[] firstRecord = csvReader.readNext();
+
+            if (firstRecord == null) {
                 Log.error("Empty file given as input.");
                 return null;
             }
-            
-            final String[] firstLine = line.split(separator);
-            int noOfAttributes = firstLine.length;
+
+            int noOfAttributes = firstRecord.length;
             if (noOfAttributes - 1 < idIndex) {
                 Log.error("Id index does not correspond to a valid column index! Counting starts from 0.");
                 return null;
             }
 
-            //setting attribute names
+            // Setting attribute names
             int entityCounter = 0;
             if (attributeNamesInFirstRow) {
-                attributeNames = Arrays.copyOf(firstLine, noOfAttributes);
+                attributeNames = Arrays.copyOf(firstRecord, noOfAttributes);
             } else { // no attribute names in csv file
                 attributeNames = new String[noOfAttributes];
                 for (int i = 0; i < noOfAttributes; i++) {
@@ -91,32 +88,33 @@ public class EntityCSVReader extends AbstractEntityReader {
                 }
 
                 entityCounter++; //first line corresponds to entity
-                readEntity(entityCounter, firstLine);
+                readEntity(entityCounter, firstRecord);
             }
 
             //read entity profiles
-            String[] nextLine;
-            while ((line = br.readLine()) != null) {
+            String[] nextRecord;
+            while ((nextRecord = csvReader.readNext()) != null) {
                 entityCounter++;
 
-                nextLine = line.split(separator);
-                if (nextLine.length < attributeNames.length - 1) {
-                    Log.warn("Line with missing attribute names : " + line);
+                if (nextRecord.length < attributeNames.length - 1) {
+                    Log.warn("Line with missing attribute names : " + Arrays.toString(nextRecord));
                     continue;
                 }
-                if (attributeNames.length < nextLine.length ) {
-                    Log.warn("Line with missing more attributes : " + line);
+                if (attributeNames.length < nextRecord.length) {
+                    Log.warn("Line with missing more attributes : " + Arrays.toString(nextRecord));
                     continue;
                 }
 
-                readEntity(entityCounter, nextLine);
+                readEntity(entityCounter, nextRecord);
             }
-            
+
             return entityProfiles;
-        } catch (IOException ex) {
-            Log.error("Error in entities reading!", ex);
+
+        } catch (IOException e) {
+            Log.error("Error in entities reading!", e);
             return null;
         }
+
     }
 
     @Override
@@ -249,7 +247,7 @@ public class EntityCSVReader extends AbstractEntityReader {
         }
     }
 
-    private void readEntity(int index, String[] currentLine) throws IOException {
+    private void readEntity(int index, String[] currentLine) {
         String entityId;
         if (idIndex < 0) {
             entityId = "id" + index;

--- a/src/test/java/org/scify/jedai/datareader/TestEntityCSVReader.java
+++ b/src/test/java/org/scify/jedai/datareader/TestEntityCSVReader.java
@@ -16,11 +16,12 @@
 
 package org.scify.jedai.datareader;
 
+import org.apache.log4j.BasicConfigurator;
 import org.scify.jedai.datamodel.Attribute;
 import org.scify.jedai.datamodel.EntityProfile;
 import org.scify.jedai.datareader.entityreader.EntityCSVReader;
+
 import java.util.List;
-import org.apache.log4j.BasicConfigurator;
 
 /**
  *
@@ -34,7 +35,7 @@ public class TestEntityCSVReader {
         String filePath = "/home/gap2/data/JedAIdata/datasets/dirtyErDatasets/dblp/articles.csv";
         EntityCSVReader csvReader = new EntityCSVReader(filePath);
         csvReader.setAttributeNamesInFirstRow(true);
-        csvReader.setSeparator(";");
+        csvReader.setSeparator(';');
 //        csvReader.setAttributesToExclude(new int[]{1});
         csvReader.setIdIndex(0);
         List<EntityProfile> profiles = csvReader.getEntityProfiles();

--- a/src/test/java/org/scify/jedai/demoworkflows/CompareXmlRdfProfiles.java
+++ b/src/test/java/org/scify/jedai/demoworkflows/CompareXmlRdfProfiles.java
@@ -15,16 +15,17 @@
  */
 package org.scify.jedai.demoworkflows;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.log4j.BasicConfigurator;
 import org.scify.jedai.datamodel.Attribute;
 import org.scify.jedai.datamodel.EntityProfile;
 import org.scify.jedai.datareader.entityreader.EntityCSVReader;
 import org.scify.jedai.datareader.entityreader.EntityRDFReader;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
@@ -48,7 +49,7 @@ public class CompareXmlRdfProfiles {
         EntityCSVReader csvEntityReader = new EntityCSVReader(mainDirectory + "ACM.csv");
         csvEntityReader.setAttributeNamesInFirstRow(true);
         csvEntityReader.setIdIndex(0);
-        csvEntityReader.setSeparator(",");
+        csvEntityReader.setSeparator(',');
         List<EntityProfile> csvDBLP = csvEntityReader.getEntityProfiles();
         System.out.println("CSV DBLP Entity Profiles\t:\t" + csvDBLP.size());
 

--- a/src/test/java/org/scify/jedai/demoworkflows/CsvDblpAcm.java
+++ b/src/test/java/org/scify/jedai/demoworkflows/CsvDblpAcm.java
@@ -15,14 +15,13 @@
  */
 package org.scify.jedai.demoworkflows;
 
-import java.io.File;
-
+import org.apache.log4j.BasicConfigurator;
 import org.rdfhdt.hdt.exceptions.ParserException;
 import org.scify.jedai.blockbuilding.IBlockBuilding;
 import org.scify.jedai.blockbuilding.StandardBlocking;
+import org.scify.jedai.blockprocessing.IBlockProcessing;
 import org.scify.jedai.blockprocessing.blockcleaning.BlockFiltering;
 import org.scify.jedai.blockprocessing.comparisoncleaning.CardinalityNodePruning;
-import org.scify.jedai.blockprocessing.IBlockProcessing;
 import org.scify.jedai.datamodel.AbstractBlock;
 import org.scify.jedai.datamodel.EntityProfile;
 import org.scify.jedai.datamodel.EquivalenceCluster;
@@ -39,9 +38,10 @@ import org.scify.jedai.utilities.BlocksPerformance;
 import org.scify.jedai.utilities.ClustersPerformance;
 import org.scify.jedai.utilities.datastructures.AbstractDuplicatePropagation;
 import org.scify.jedai.utilities.datastructures.BilateralDuplicatePropagation;
+
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
-import org.apache.log4j.BasicConfigurator;
 
 /**
  *
@@ -57,14 +57,14 @@ public class CsvDblpAcm {
         EntityCSVReader csvEntityReader = new EntityCSVReader(mainDirectory + "DBLP2.csv");
         csvEntityReader.setAttributeNamesInFirstRow(true);
         csvEntityReader.setIdIndex(0);
-        csvEntityReader.setSeparator(",");
+        csvEntityReader.setSeparator(',');
         List<EntityProfile> csvDBLP = csvEntityReader.getEntityProfiles();
         System.out.println("CSV DBLP Entity Profiles\t:\t" + csvDBLP.size());
         
         csvEntityReader = new EntityCSVReader(mainDirectory + "ACM.csv");
         csvEntityReader.setAttributeNamesInFirstRow(true);
         csvEntityReader.setIdIndex(0);
-        csvEntityReader.setSeparator(",");
+        csvEntityReader.setSeparator(',');
         List<EntityProfile> csvACM = csvEntityReader.getEntityProfiles();
         System.out.println("CSV ACM Entity Profiles\t:\t" + csvACM.size());
 

--- a/src/test/java/org/scify/jedai/demoworkflows/RdfCsvDblpAcm.java
+++ b/src/test/java/org/scify/jedai/demoworkflows/RdfCsvDblpAcm.java
@@ -15,30 +15,31 @@
  */
 package org.scify.jedai.demoworkflows;
 
-import org.scify.jedai.demoworkflows.groundtruth.GtDblpRdfAcmCsvReader;
+import org.apache.log4j.BasicConfigurator;
 import org.scify.jedai.blockbuilding.IBlockBuilding;
 import org.scify.jedai.blockbuilding.StandardBlocking;
+import org.scify.jedai.blockprocessing.IBlockProcessing;
 import org.scify.jedai.blockprocessing.blockcleaning.BlockFiltering;
 import org.scify.jedai.blockprocessing.comparisoncleaning.CardinalityNodePruning;
-import org.scify.jedai.blockprocessing.IBlockProcessing;
 import org.scify.jedai.datamodel.AbstractBlock;
 import org.scify.jedai.datamodel.EntityProfile;
 import org.scify.jedai.datamodel.EquivalenceCluster;
 import org.scify.jedai.datamodel.SimilarityPairs;
 import org.scify.jedai.datareader.entityreader.EntityCSVReader;
 import org.scify.jedai.datareader.entityreader.EntityRDFReader;
+import org.scify.jedai.demoworkflows.groundtruth.GtDblpRdfAcmCsvReader;
 import org.scify.jedai.entityclustering.ConnectedComponentsClustering;
 import org.scify.jedai.entityclustering.IEntityClustering;
 import org.scify.jedai.entitymatching.IEntityMatching;
 import org.scify.jedai.entitymatching.ProfileMatcher;
 import org.scify.jedai.utilities.BlocksPerformance;
 import org.scify.jedai.utilities.ClustersPerformance;
+import org.scify.jedai.utilities.PrintToFile;
 import org.scify.jedai.utilities.datastructures.AbstractDuplicatePropagation;
 import org.scify.jedai.utilities.datastructures.BilateralDuplicatePropagation;
-import org.scify.jedai.utilities.PrintToFile;
+
 import java.io.FileNotFoundException;
 import java.util.List;
-import org.apache.log4j.BasicConfigurator;
 
 /**
  *
@@ -63,7 +64,7 @@ public class RdfCsvDblpAcm {
         EntityCSVReader csvEntityReader = new EntityCSVReader(mainDirectory + "ACM.csv");
         csvEntityReader.setAttributeNamesInFirstRow(true);
         csvEntityReader.setIdIndex(0);
-        csvEntityReader.setSeparator(",");
+        csvEntityReader.setSeparator(',');
         List<EntityProfile> csvACM = csvEntityReader.getEntityProfiles();
         System.out.println("RDF ACM Entity Profiles\t:\t" + csvACM.size());
 

--- a/src/test/java/org/scify/jedai/similarityjoins/TestAllMethodsDirtyER.java
+++ b/src/test/java/org/scify/jedai/similarityjoins/TestAllMethodsDirtyER.java
@@ -41,7 +41,7 @@ public class TestAllMethodsDirtyER {
         testJedaiEntityReader = new EntityCSVReader(mainDirectory + "testJedai.txt");
         testJedaiEntityReader.setAttributeNamesInFirstRow(false);
         //csvEntityReader.setIdIndex(0);
-        testJedaiEntityReader.setSeparator(";");
+        testJedaiEntityReader.setSeparator(';');
         List<EntityProfile> csvACM = testJedaiEntityReader.getEntityProfiles();
 
         //System.out.println("CSV ACM Entity Profiles\t:\t" + csvACM.size());

--- a/src/test/java/org/scify/jedai/similarityjoins/TestSimJoinsWithDirtyERdatasets.java
+++ b/src/test/java/org/scify/jedai/similarityjoins/TestSimJoinsWithDirtyERdatasets.java
@@ -102,7 +102,7 @@ public class TestSimJoinsWithDirtyERdatasets {
         testJedaiEntityReader = new EntityCSVReader(mainDirectory + "testJedaiACMdplp.txt");
         testJedaiEntityReader.setAttributeNamesInFirstRow(false);
         //csvEntityReader.setIdIndex(0);
-        testJedaiEntityReader.setSeparator(";");
+        testJedaiEntityReader.setSeparator(';');
         List<EntityProfile> csvACM = testJedaiEntityReader.getEntityProfiles();
 
         //List<EntityProfile> profiles = getDatasetAggregateValues(entitiesFilePath);


### PR DESCRIPTION
For example

`"World Wide Database-integrating the Web, CORBA and databases"`

should not be separated to

`"World Wide   Database-integrating the Web"` & `"CORBA and databases"`

Separator changed to char type to follow the specs of OpenCSV


