### PR TITLE
Issue #34 - Reduce the memory footprint of SimilarityPairs...

### DIFF
--- a/src/main/java/org/scify/jedai/datamodel/Comparison.java
+++ b/src/main/java/org/scify/jedai/datamodel/Comparison.java
@@ -65,6 +65,10 @@ public class Comparison implements Serializable {
         return entityId2;
     }
     
+    /**
+     * Returns the measure of the weight or similarity between two entities. Higher utility measures
+     * correspond to greater weight or stronger similarity.
+     */
     public double getUtilityMeasure() {
         return utilityMeasure;
     }
@@ -81,6 +85,7 @@ public class Comparison implements Serializable {
         return cleanCleanER;
     }
     
+    /** @see #getUtilityMeasure() */
     public void setUtilityMeasure(double utilityMeasure) {
         this.utilityMeasure = utilityMeasure;
     }

--- a/src/main/java/org/scify/jedai/datamodel/EntityProfile.java
+++ b/src/main/java/org/scify/jedai/datamodel/EntityProfile.java
@@ -21,10 +21,12 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
+ * The representation of a single entity or record. An entity is comprised of one or more
+ * {@link #getAttributes() Attribute} name/value pairs and a {@link #getEntityUrl() URL} which 
+ * uniquely identifies each entity.
  *
  * @author G.A.P. II
  */
-
 public class EntityProfile implements Serializable {
 
     private static final long serialVersionUID = 122354534453243447L;
@@ -34,7 +36,7 @@ public class EntityProfile implements Serializable {
 
     public EntityProfile(String url) {
         entityUrl = url;
-        attributes = new HashSet();
+        attributes = new HashSet<>();
     }
 
     public void addAttribute(String propertyName, String propertyValue) {

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -29,7 +29,7 @@ public class SimilarityPairs implements IConstants, Serializable {
 
     private final boolean isCleanCleanER;
     private int currentIndex;
-    private final double[] similarities;
+    private final float[] similarities;
     private final int[] entityIds1;
     private final int[] entityIds2;
 
@@ -38,7 +38,7 @@ public class SimilarityPairs implements IConstants, Serializable {
         isCleanCleanER = ccer;
         entityIds1 = new int[comparisons];
         entityIds2 = new int[comparisons];
-        similarities = new double[comparisons];
+        similarities = new float[comparisons];
     }
     
     public SimilarityPairs(boolean ccer, List<AbstractBlock> blocks) {
@@ -47,13 +47,13 @@ public class SimilarityPairs implements IConstants, Serializable {
         double totalComparisons = countComparisons(blocks);
         entityIds1 = new int[(int) totalComparisons];
         entityIds2 = new int[(int) totalComparisons];
-        similarities = new double[(int) totalComparisons];
+        similarities = new float[(int) totalComparisons];
     }
 
     public void addComparison(Comparison comparison) {
         entityIds1[currentIndex] = comparison.getEntityId1();
         entityIds2[currentIndex] = comparison.getEntityId2();
-        similarities[currentIndex++] = comparison.getUtilityMeasure();
+        similarities[currentIndex++] = (float) comparison.getUtilityMeasure();
     }
 
     private double countComparisons(List<AbstractBlock> blocks) {
@@ -86,7 +86,7 @@ public class SimilarityPairs implements IConstants, Serializable {
         return new PairIterator(this);
     }
 
-    public double[] getSimilarities() {
+    public float[] getSimilarities() {
         return similarities;
     }
 

--- a/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
+++ b/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
@@ -144,7 +144,7 @@ public class GroupLinkage extends AbstractEntityMatching {
         RepresentationModel.resetGlobalValues(datasetId, representationModel);
         for (EntityProfile profile : profiles) {
             int validAttributes = 0;
-            validAttributes = profile.getAttributes().stream().filter((attribute) -> (!attribute.getValue().isEmpty())).map((_item) -> 1).reduce(validAttributes, Integer::sum);
+            validAttributes = profile.getAttributes().stream().filter((attribute) -> (!attribute.getValue().isEmpty())).mapToInt(_item -> 1).sum();
 
             int counter = 0;
             ModelsList[entityCounter] = new ITextModel[validAttributes];


### PR DESCRIPTION
...by changing the storage of utility measure from doubles to floats.

I kept the scope of the change mostly to `SimilarityPairs` to keep the change set small. If you agree that this is a worthwhile change, I'd be happy to flip `Comparison.getUtilityMeasure()` to float and propagate those changes throughout the code base.