### PR TITLE
Issue #48 - Change comparison counts type to int

### DIFF
--- a/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
@@ -30,7 +30,7 @@ import java.util.List;
 public abstract class AbstractBlockProcessing implements IBlockProcessing {
     
     protected void printOriginalStatistics(List<AbstractBlock> inputBlocks) {
-        float comparisons = 0;
+        int comparisons = 0;
         comparisons = inputBlocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
         
         Log.info("Original blocks\t:\t" + inputBlocks.size());

--- a/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
@@ -30,9 +30,8 @@ import java.util.List;
 public abstract class AbstractBlockProcessing implements IBlockProcessing {
     
     protected void printOriginalStatistics(List<AbstractBlock> inputBlocks) {
-        long comparisons = 0;
-        comparisons = inputBlocks.stream().map((block) -> (long) block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
-        
+        long comparisons = inputBlocks.stream().mapToLong(AbstractBlock::getNoOfComparisons).sum();
+
         Log.info("Original blocks\t:\t" + inputBlocks.size());
         Log.info("Original comparisons\t:\t" + comparisons);
     }

--- a/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
@@ -31,7 +31,7 @@ public abstract class AbstractBlockProcessing implements IBlockProcessing {
     
     protected void printOriginalStatistics(List<AbstractBlock> inputBlocks) {
         long comparisons = 0;
-        comparisons = inputBlocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
+        comparisons = inputBlocks.stream().map((block) -> (long) block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
         
         Log.info("Original blocks\t:\t" + inputBlocks.size());
         Log.info("Original comparisons\t:\t" + comparisons);

--- a/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/AbstractBlockProcessing.java
@@ -30,7 +30,7 @@ import java.util.List;
 public abstract class AbstractBlockProcessing implements IBlockProcessing {
     
     protected void printOriginalStatistics(List<AbstractBlock> inputBlocks) {
-        int comparisons = 0;
+        long comparisons = 0;
         comparisons = inputBlocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
         
         Log.info("Original blocks\t:\t" + inputBlocks.size());

--- a/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/CanopyClustering.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/CanopyClustering.java
@@ -15,7 +15,6 @@
  */
 package org.scify.jedai.blockprocessing.comparisoncleaning;
 
-import com.esotericsoftware.minlog.Log;
 import org.scify.jedai.datamodel.AbstractBlock;
 import org.scify.jedai.utilities.enumerations.WeightingScheme;
 import gnu.trove.iterator.TIntIterator;
@@ -56,7 +55,8 @@ public class CanopyClustering extends CardinalityNodePruning {
         exclusiveThreshold = outThr;
         inclusiveThreshold = inThr;
         if (exclusiveThreshold < inclusiveThreshold) {
-        	throw new RuntimeException("The " + getParameterName(1) + " cannot be smaller than the " + getParameterName(0));
+            throw new IllegalStateException(
+                    "The " + getParameterName(1) + " cannot be smaller than the " + getParameterName(0));
         }
     }
 

--- a/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/CanopyClustering.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/CanopyClustering.java
@@ -56,8 +56,7 @@ public class CanopyClustering extends CardinalityNodePruning {
         exclusiveThreshold = outThr;
         inclusiveThreshold = inThr;
         if (exclusiveThreshold < inclusiveThreshold) {
-            Log.error(getMethodName(), "The " + getParameterName(1) + " cannot be smaller than the " + getParameterName(0));
-            System.exit(-1);
+        	throw new RuntimeException("The " + getParameterName(1) + " cannot be smaller than the " + getParameterName(0));
         }
     }
 

--- a/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/ExtendedCanopyClustering.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/ExtendedCanopyClustering.java
@@ -15,7 +15,6 @@
  */
 package org.scify.jedai.blockprocessing.comparisoncleaning;
 
-import com.esotericsoftware.minlog.Log;
 import org.scify.jedai.datamodel.AbstractBlock;
 import org.scify.jedai.datamodel.Comparison;
 import org.scify.jedai.utilities.enumerations.WeightingScheme;
@@ -60,7 +59,7 @@ public class ExtendedCanopyClustering extends CardinalityNodePruning {
         exclusiveThreshold = outThr;
         inclusiveThreshold = inThr;
         if (inclusiveThreshold < exclusiveThreshold) {
-        	throw new RuntimeException("The Exclusive Threshold cannot be larger than the Inclusive one.");
+            throw new IllegalStateException("The Exclusive Threshold cannot be larger than the Inclusive one.");
         }
     }
 

--- a/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/ExtendedCanopyClustering.java
+++ b/src/main/java/org/scify/jedai/blockprocessing/comparisoncleaning/ExtendedCanopyClustering.java
@@ -60,8 +60,7 @@ public class ExtendedCanopyClustering extends CardinalityNodePruning {
         exclusiveThreshold = outThr;
         inclusiveThreshold = inThr;
         if (inclusiveThreshold < exclusiveThreshold) {
-            Log.error(getMethodName(), "The Exclusive Threshold cannot be larger than the Inclusive one.");
-            System.exit(-1);
+        	throw new RuntimeException("The Exclusive Threshold cannot be larger than the Inclusive one.");
         }
     }
 

--- a/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
@@ -31,7 +31,7 @@ public abstract class AbstractBlock implements Serializable {
     
     protected int blockIndex;
     
-    protected float comparisons;
+    protected int comparisons;
     protected float entropy;
     protected float utilityMeasure;
             
@@ -53,7 +53,7 @@ public abstract class AbstractBlock implements Serializable {
         return entropy;
     }
 
-    public float getNoOfComparisons() {
+    public int getNoOfComparisons() {
         return comparisons;
     }
     

--- a/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
@@ -31,7 +31,7 @@ public abstract class AbstractBlock implements Serializable {
     
     protected int blockIndex;
     
-    protected long comparisons;
+    protected int comparisons;
     protected float entropy;
     protected float utilityMeasure;
             
@@ -53,7 +53,7 @@ public abstract class AbstractBlock implements Serializable {
         return entropy;
     }
 
-    public long getNoOfComparisons() {
+    public int getNoOfComparisons() {
         return comparisons;
     }
     

--- a/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/AbstractBlock.java
@@ -31,7 +31,7 @@ public abstract class AbstractBlock implements Serializable {
     
     protected int blockIndex;
     
-    protected int comparisons;
+    protected long comparisons;
     protected float entropy;
     protected float utilityMeasure;
             
@@ -53,7 +53,7 @@ public abstract class AbstractBlock implements Serializable {
         return entropy;
     }
 
-    public int getNoOfComparisons() {
+    public long getNoOfComparisons() {
         return comparisons;
     }
     

--- a/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
@@ -39,7 +39,7 @@ public class BilateralBlock extends AbstractBlock implements Serializable {
         super(entropy);
         index1Entities = entities1;
         index2Entities = entities2;
-        comparisons = ((float) index1Entities.length) * ((float) index2Entities.length);
+        comparisons = index1Entities.length * index2Entities.length;
     }
 
     @Override

--- a/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
@@ -39,7 +39,7 @@ public class BilateralBlock extends AbstractBlock implements Serializable {
         super(entropy);
         index1Entities = entities1;
         index2Entities = entities2;
-        comparisons = index1Entities.length * index2Entities.length;
+        comparisons = (long) index1Entities.length * index2Entities.length;
     }
 
     @Override

--- a/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
@@ -21,6 +21,8 @@ import static org.scify.jedai.utilities.IConstants.MAX_COMPARISONS;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import org.scify.jedai.utilities.TooManyComparisonsException;
+
 /**
  *
  * @author G.A.P. II
@@ -44,8 +46,7 @@ public class BilateralBlock extends AbstractBlock implements Serializable {
         long comparisonNo = (long) index1Entities.length * index2Entities.length;
 
         if (MAX_COMPARISONS < comparisonNo) {
-            throw new IllegalStateException("Very high number of comparisons to be executed! "
-                    + "Maximum allowed number is : " + MAX_COMPARISONS);
+            throw new TooManyComparisonsException(comparisonNo);
         }
 
         comparisons = (int) comparisonNo;

--- a/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/BilateralBlock.java
@@ -16,6 +16,8 @@
 
 package org.scify.jedai.datamodel;
 
+import static org.scify.jedai.utilities.IConstants.MAX_COMPARISONS;
+
 import java.io.Serializable;
 import java.util.Arrays;
 
@@ -39,7 +41,14 @@ public class BilateralBlock extends AbstractBlock implements Serializable {
         super(entropy);
         index1Entities = entities1;
         index2Entities = entities2;
-        comparisons = (long) index1Entities.length * index2Entities.length;
+        long comparisonNo = (long) index1Entities.length * index2Entities.length;
+
+        if (MAX_COMPARISONS < comparisonNo) {
+            throw new IllegalStateException("Very high number of comparisons to be executed! "
+                    + "Maximum allowed number is : " + MAX_COMPARISONS);
+        }
+
+        comparisons = (int) comparisonNo;
     }
 
     @Override

--- a/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
+++ b/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
  */
 public class ComparisonIterator implements IConstants, Iterator<Comparison> {
 
-    private int executedComparisons;
-    private final int totalComparisons;
+    private long executedComparisons;
+    private final long totalComparisons;
 
     private int innerLoop;
     private int innerLimit;

--- a/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
+++ b/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
  */
 public class ComparisonIterator implements IConstants, Iterator<Comparison> {
 
-    private float executedComparisons;
-    private final float totalComparisons;
+    private int executedComparisons;
+    private final int totalComparisons;
 
     private int innerLoop;
     private int innerLimit;

--- a/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
+++ b/src/main/java/org/scify/jedai/datamodel/ComparisonIterator.java
@@ -26,8 +26,8 @@ import java.util.Iterator;
  */
 public class ComparisonIterator implements IConstants, Iterator<Comparison> {
 
-    private long executedComparisons;
-    private final long totalComparisons;
+    private int executedComparisons;
+    private final int totalComparisons;
 
     private int innerLoop;
     private int innerLimit;

--- a/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
@@ -60,7 +60,7 @@ public class DecomposedBlock extends AbstractBlock {
     }
     
     @Override
-    public float getNoOfComparisons() {
+    public int getNoOfComparisons() {
         return entities1.length;
     }
 

--- a/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
@@ -60,7 +60,7 @@ public class DecomposedBlock extends AbstractBlock {
     }
     
     @Override
-    public long getNoOfComparisons() {
+    public int getNoOfComparisons() {
         return entities1.length;
     }
 

--- a/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/DecomposedBlock.java
@@ -60,7 +60,7 @@ public class DecomposedBlock extends AbstractBlock {
     }
     
     @Override
-    public int getNoOfComparisons() {
+    public long getNoOfComparisons() {
         return entities1.length;
     }
 

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -52,17 +52,17 @@ public class SimilarityPairs implements IConstants, Serializable {
     public void addComparison(Comparison comparison) {
         entityIds1[currentIndex] = comparison.getEntityId1();
         entityIds2[currentIndex] = comparison.getEntityId2();
-        similarities[currentIndex++] = (float) comparison.getUtilityMeasure();
+        similarities[currentIndex++] = comparison.getUtilityMeasure();
     }
 
     private int countComparisons(List<AbstractBlock> blocks) {
-        long comparisons = 0;
-        comparisons = blocks.stream().map((block) -> (long) block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
+        long comparisons = blocks.stream().mapToLong(AbstractBlock::getNoOfComparisons).sum();
 
         if (MAX_COMPARISONS < comparisons) {
             throw new IllegalStateException("Very high number of comparisons to be executed! "
                     + "Maximum allowed number is : " + MAX_COMPARISONS);
         }
+
         return (int) comparisons;
     }
 

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -44,7 +44,7 @@ public class SimilarityPairs implements IConstants, Serializable {
     public SimilarityPairs(boolean ccer, List<AbstractBlock> blocks) {
         currentIndex = 0;
         isCleanCleanER = ccer;
-        float totalComparisons = countComparisons(blocks);
+        int totalComparisons = countComparisons(blocks);
         entityIds1 = new int[(int) totalComparisons];
         entityIds2 = new int[(int) totalComparisons];
         similarities = new float[(int) totalComparisons];
@@ -56,8 +56,8 @@ public class SimilarityPairs implements IConstants, Serializable {
         similarities[currentIndex++] = (float) comparison.getUtilityMeasure();
     }
 
-    private float countComparisons(List<AbstractBlock> blocks) {
-        float comparisons = 0;
+    private int countComparisons(List<AbstractBlock> blocks) {
+        int comparisons = 0;
         comparisons = blocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
 
         if (MAX_COMPARISONS < comparisons) {

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -61,9 +61,8 @@ public class SimilarityPairs implements IConstants, Serializable {
         comparisons = blocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
 
         if (MAX_COMPARISONS < comparisons) {
-            Log.error("Very high number of comparisons to be executed! "
+           throw new RuntimeException("Very high number of comparisons to be executed! "
                     + "Maximum allowed number is : " + MAX_COMPARISONS);
-            System.exit(-1);
         }
         return comparisons;
     }

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -45,9 +45,9 @@ public class SimilarityPairs implements IConstants, Serializable {
         currentIndex = 0;
         isCleanCleanER = ccer;
         int totalComparisons = countComparisons(blocks);
-        entityIds1 = new int[(int) totalComparisons];
-        entityIds2 = new int[(int) totalComparisons];
-        similarities = new float[(int) totalComparisons];
+        entityIds1 = new int[totalComparisons];
+        entityIds2 = new int[totalComparisons];
+        similarities = new float[totalComparisons];
     }
 
     public void addComparison(Comparison comparison) {
@@ -57,14 +57,14 @@ public class SimilarityPairs implements IConstants, Serializable {
     }
 
     private int countComparisons(List<AbstractBlock> blocks) {
-        int comparisons = 0;
+        long comparisons = 0;
         comparisons = blocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
 
         if (MAX_COMPARISONS < comparisons) {
            throw new RuntimeException("Very high number of comparisons to be executed! "
                     + "Maximum allowed number is : " + MAX_COMPARISONS);
         }
-        return comparisons;
+        return (int) comparisons;
     }
 
     public int[] getEntityIds1() {

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -15,7 +15,6 @@
  */
 package org.scify.jedai.datamodel;
 
-import com.esotericsoftware.minlog.Log;
 import java.io.Serializable;
 
 import java.util.List;
@@ -58,10 +57,10 @@ public class SimilarityPairs implements IConstants, Serializable {
 
     private int countComparisons(List<AbstractBlock> blocks) {
         long comparisons = 0;
-        comparisons = blocks.stream().map((block) -> block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
+        comparisons = blocks.stream().map((block) -> (long) block.getNoOfComparisons()).reduce(comparisons, (accumulator, _item) -> accumulator + _item);
 
         if (MAX_COMPARISONS < comparisons) {
-           throw new RuntimeException("Very high number of comparisons to be executed! "
+            throw new IllegalStateException("Very high number of comparisons to be executed! "
                     + "Maximum allowed number is : " + MAX_COMPARISONS);
         }
         return (int) comparisons;

--- a/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
+++ b/src/main/java/org/scify/jedai/datamodel/SimilarityPairs.java
@@ -18,6 +18,8 @@ package org.scify.jedai.datamodel;
 import java.io.Serializable;
 
 import java.util.List;
+
+import org.scify.jedai.utilities.TooManyComparisonsException;
 import org.scify.jedai.utilities.IConstants;
 
 /**
@@ -59,8 +61,7 @@ public class SimilarityPairs implements IConstants, Serializable {
         long comparisons = blocks.stream().mapToLong(AbstractBlock::getNoOfComparisons).sum();
 
         if (MAX_COMPARISONS < comparisons) {
-            throw new IllegalStateException("Very high number of comparisons to be executed! "
-                    + "Maximum allowed number is : " + MAX_COMPARISONS);
+            throw new TooManyComparisonsException(comparisons);
         }
 
         return (int) comparisons;

--- a/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
@@ -16,8 +16,11 @@
 
 package org.scify.jedai.datamodel;
 
+import static org.scify.jedai.utilities.IConstants.MAX_COMPARISONS;
+
 import java.io.Serializable;
 import java.util.Arrays;
+
 
 /**
  *
@@ -37,7 +40,14 @@ public class UnilateralBlock extends AbstractBlock implements Serializable {
     public UnilateralBlock(float entropy, int[] entities) {
         super(entropy);
         this.entities = entities;
-        comparisons = entities.length * (entities.length - 1)/2;
+        long comparisonNo = entities.length * (entities.length - 1) / 2;
+
+        if (MAX_COMPARISONS < comparisonNo) {
+            throw new IllegalStateException("Very high number of comparisons to be executed! "
+                    + "Maximum allowed number is : " + MAX_COMPARISONS);
+        }
+
+        comparisons = (int) comparisonNo;
     }
     
     @Override

--- a/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
@@ -21,6 +21,7 @@ import static org.scify.jedai.utilities.IConstants.MAX_COMPARISONS;
 import java.io.Serializable;
 import java.util.Arrays;
 
+import org.scify.jedai.utilities.TooManyComparisonsException;
 
 /**
  *
@@ -43,8 +44,7 @@ public class UnilateralBlock extends AbstractBlock implements Serializable {
         long comparisonNo = entities.length * (entities.length - 1) / 2;
 
         if (MAX_COMPARISONS < comparisonNo) {
-            throw new IllegalStateException("Very high number of comparisons to be executed! "
-                    + "Maximum allowed number is : " + MAX_COMPARISONS);
+            throw new TooManyComparisonsException(comparisonNo);
         }
 
         comparisons = (int) comparisonNo;

--- a/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
+++ b/src/main/java/org/scify/jedai/datamodel/UnilateralBlock.java
@@ -37,7 +37,7 @@ public class UnilateralBlock extends AbstractBlock implements Serializable {
     public UnilateralBlock(float entropy, int[] entities) {
         super(entropy);
         this.entities = entities;
-        comparisons = entities.length*(entities.length-1.0f)/2.0f;
+        comparisons = entities.length * (entities.length - 1)/2;
     }
     
     @Override

--- a/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
+++ b/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
@@ -63,9 +63,8 @@ public class GroupLinkage extends AbstractEntityMatching {
     @Override
     protected final void buildModels() {
         if (profilesD1 == null) {
-            Log.error("First list of entity profiles is null! "
+        	throw new RuntimeException("First list of entity profiles is null! "
                     + "The first argument should always contain entities.");
-            System.exit(-1);
         }
 
         if (entityModelsD1 == null) {

--- a/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
+++ b/src/main/java/org/scify/jedai/entitymatching/GroupLinkage.java
@@ -63,8 +63,8 @@ public class GroupLinkage extends AbstractEntityMatching {
     @Override
     protected final void buildModels() {
         if (profilesD1 == null) {
-        	throw new RuntimeException("First list of entity profiles is null! "
-                    + "The first argument should always contain entities.");
+            throw new IllegalStateException(
+                    "First list of entity profiles is null! The first argument should always contain entities.");
         }
 
         if (entityModelsD1 == null) {

--- a/src/main/java/org/scify/jedai/entitymatching/ProfileMatcher.java
+++ b/src/main/java/org/scify/jedai/entitymatching/ProfileMatcher.java
@@ -55,9 +55,8 @@ public class ProfileMatcher extends AbstractEntityMatching {
     @Override
     protected final void buildModels() {
         if (profilesD1 == null) {
-            Log.error("First list of entity profiles is null! "
+        	throw new RuntimeException("First list of entity profiles is null! "
                     + "The first argument should always contain entities.");
-            System.exit(-1);
         }
 
         Log.info("Applying " + getMethodName() + " with the following configuration : " + getMethodConfiguration());

--- a/src/main/java/org/scify/jedai/entitymatching/ProfileMatcher.java
+++ b/src/main/java/org/scify/jedai/entitymatching/ProfileMatcher.java
@@ -55,8 +55,8 @@ public class ProfileMatcher extends AbstractEntityMatching {
     @Override
     protected final void buildModels() {
         if (profilesD1 == null) {
-        	throw new RuntimeException("First list of entity profiles is null! "
-                    + "The first argument should always contain entities.");
+            throw new IllegalArgumentException(
+                    "First list of entity profiles is null! The first argument should always contain entities.");
         }
 
         Log.info("Applying " + getMethodName() + " with the following configuration : " + getMethodConfiguration());

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveBlockScheduling.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveBlockScheduling.java
@@ -15,7 +15,6 @@
  */
 package org.scify.jedai.prioritization;
 
-import com.esotericsoftware.minlog.Log;
 import org.scify.jedai.datamodel.AbstractBlock;
 import org.scify.jedai.datamodel.Comparison;
 import org.scify.jedai.datamodel.ComparisonIterator;
@@ -49,7 +48,7 @@ public class ProgressiveBlockScheduling extends AbstractHashBasedPrioritization 
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-        	throw new RuntimeException("No blocks were given as input!");
+            throw new IllegalArgumentException("No blocks were given as input!");
         }
 
         blocks.sort(new IncBlockCardinalityComparator());

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveBlockScheduling.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveBlockScheduling.java
@@ -49,8 +49,7 @@ public class ProgressiveBlockScheduling extends AbstractHashBasedPrioritization 
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-            Log.error("No blocks were given as input!");
-            System.exit(-1);
+        	throw new RuntimeException("No blocks were given as input!");
         }
 
         blocks.sort(new IncBlockCardinalityComparator());

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveEntityScheduling.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveEntityScheduling.java
@@ -15,7 +15,6 @@
  */
 package org.scify.jedai.prioritization;
 
-import com.esotericsoftware.minlog.Log;
 import java.util.Iterator;
 import java.util.List;
 import org.scify.jedai.datamodel.AbstractBlock;
@@ -44,7 +43,7 @@ public class ProgressiveEntityScheduling extends AbstractHashBasedPrioritization
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-        	throw new RuntimeException("No blocks were given as input!");
+            throw new IllegalArgumentException("No blocks were given as input!");
         }
 
         final ProgressiveWNP pwnp = new ProgressiveWNP(wScheme);

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveEntityScheduling.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveEntityScheduling.java
@@ -44,8 +44,7 @@ public class ProgressiveEntityScheduling extends AbstractHashBasedPrioritization
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-            Log.error("No blocks were given as input!");
-            System.exit(-1);
+        	throw new RuntimeException("No blocks were given as input!");
         }
 
         final ProgressiveWNP pwnp = new ProgressiveWNP(wScheme);

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveGlobalTopComparisons.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveGlobalTopComparisons.java
@@ -47,8 +47,7 @@ public class ProgressiveGlobalTopComparisons extends AbstractHashBasedPrioritiza
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-            Log.error("No blocks were given as input!");
-            System.exit(-1);
+        	throw new RuntimeException("No blocks were given as input!");
         }
 
         if (blocks.get(0) instanceof DecomposedBlock) {

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveGlobalTopComparisons.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveGlobalTopComparisons.java
@@ -47,7 +47,7 @@ public class ProgressiveGlobalTopComparisons extends AbstractHashBasedPrioritiza
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-        	throw new RuntimeException("No blocks were given as input!");
+            throw new IllegalArgumentException("No blocks were given as input!");
         }
 
         if (blocks.get(0) instanceof DecomposedBlock) {

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveLocalTopComparisons.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveLocalTopComparisons.java
@@ -41,7 +41,7 @@ public class ProgressiveLocalTopComparisons extends AbstractHashBasedPrioritizat
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-        	throw new RuntimeException("No blocks were given as input!");
+            throw new IllegalArgumentException("No blocks were given as input!");
         }
 
         if (blocks.get(0) instanceof DecomposedBlock) {

--- a/src/main/java/org/scify/jedai/prioritization/ProgressiveLocalTopComparisons.java
+++ b/src/main/java/org/scify/jedai/prioritization/ProgressiveLocalTopComparisons.java
@@ -41,8 +41,7 @@ public class ProgressiveLocalTopComparisons extends AbstractHashBasedPrioritizat
     @Override
     public void developBlockBasedSchedule(List<AbstractBlock> blocks) {
         if (blocks == null || blocks.isEmpty()) {
-            Log.error("No blocks were given as input!");
-            System.exit(-1);
+        	throw new RuntimeException("No blocks were given as input!");
         }
 
         if (blocks.get(0) instanceof DecomposedBlock) {

--- a/src/main/java/org/scify/jedai/textmodels/BagModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/BagModel.java
@@ -17,7 +17,6 @@ package org.scify.jedai.textmodels;
 
 import org.scify.jedai.utilities.enumerations.RepresentationModel;
 import org.scify.jedai.utilities.enumerations.SimilarityMetric;
-import com.esotericsoftware.minlog.Log;
 import gnu.trove.iterator.TObjectIntIterator;
 import gnu.trove.map.TObjectIntMap;
 import gnu.trove.map.hash.TObjectIntHashMap;
@@ -112,7 +111,8 @@ public abstract class BagModel extends AbstractModel {
             case JACCARD_SIMILARITY:
                 return getJaccardSimilarity((BagModel) oModel);
             default:
-            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
+            throw new IllegalStateException(
+                    "The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/BagModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/BagModel.java
@@ -111,7 +111,7 @@ public abstract class BagModel extends AbstractModel {
             case JACCARD_SIMILARITY:
                 return getJaccardSimilarity((BagModel) oModel);
             default:
-            throw new IllegalStateException(
+                throw new IllegalStateException(
                     "The given similarity metric is incompatible with the bag representation model!");
         }
     }

--- a/src/main/java/org/scify/jedai/textmodels/BagModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/BagModel.java
@@ -112,9 +112,7 @@ public abstract class BagModel extends AbstractModel {
             case JACCARD_SIMILARITY:
                 return getJaccardSimilarity((BagModel) oModel);
             default:
-                Log.error("The given similarity metric is incompatible with the bag representation model!");
-                System.exit(-1);
-                return -1;
+            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/CharacterNGramsWithGlobalWeights.java
+++ b/src/main/java/org/scify/jedai/textmodels/CharacterNGramsWithGlobalWeights.java
@@ -57,8 +57,7 @@ public class CharacterNGramsWithGlobalWeights extends CharacterNGrams {
         } else if (datasetId != oModel.getDatasetId()) { // Clean-Clean ER
             similarity = commonKeys.stream().map((key) -> 1.0f / ((float) Math.log1p(((float) DOC_FREQ[DATASET_1].get(key)) * DOC_FREQ[DATASET_2].get(key)) / (float) Math.log(2))).reduce(similarity, (accumulator, _item) -> accumulator + _item);
         } else {
-            Log.error("Both models come from dataset 1!");
-            System.exit(-1);
+        	throw new RuntimeException("Both models come from dataset 1!");
         }
 
         return similarity;
@@ -113,9 +112,7 @@ public class CharacterNGramsWithGlobalWeights extends CharacterNGrams {
             case SIGMA_SIMILARITY:
                 return getSigmaSimilarity((CharacterNGramsWithGlobalWeights) oModel);
             default:
-                Log.error("The given similarity metric is incompatible with the bag representation model!");
-                System.exit(-1);
-                return -1;
+            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/CharacterNGramsWithGlobalWeights.java
+++ b/src/main/java/org/scify/jedai/textmodels/CharacterNGramsWithGlobalWeights.java
@@ -57,7 +57,7 @@ public class CharacterNGramsWithGlobalWeights extends CharacterNGrams {
         } else if (datasetId != oModel.getDatasetId()) { // Clean-Clean ER
             similarity = commonKeys.stream().map((key) -> 1.0f / ((float) Math.log1p(((float) DOC_FREQ[DATASET_1].get(key)) * DOC_FREQ[DATASET_2].get(key)) / (float) Math.log(2))).reduce(similarity, (accumulator, _item) -> accumulator + _item);
         } else {
-        	throw new RuntimeException("Both models come from dataset 1!");
+            throw new IllegalStateException("Both models come from dataset 1!");
         }
 
         return similarity;
@@ -112,7 +112,8 @@ public class CharacterNGramsWithGlobalWeights extends CharacterNGrams {
             case SIGMA_SIMILARITY:
                 return getSigmaSimilarity((CharacterNGramsWithGlobalWeights) oModel);
             default:
-            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
+            throw new IllegalStateException(
+                    "The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/GraphModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/GraphModel.java
@@ -17,7 +17,6 @@ package org.scify.jedai.textmodels;
 
 import org.scify.jedai.utilities.enumerations.RepresentationModel;
 import org.scify.jedai.utilities.enumerations.SimilarityMetric;
-import com.esotericsoftware.minlog.Log;
 import gr.demokritos.iit.jinsect.documentModel.comparators.NGramCachedGraphComparator;
 import gr.demokritos.iit.jinsect.documentModel.representations.DocumentNGramGraph;
 import gr.demokritos.iit.jinsect.structs.GraphSimilarity;
@@ -74,7 +73,8 @@ public abstract class GraphModel extends AbstractModel {
                 }
                 return (float)(overallSimilarity / 2);
             default:
-            	throw new RuntimeException("The given similarity metric is incompatible with the n-gram graphs representation model!");
+            throw new IllegalStateException(
+                    "The given similarity metric is incompatible with the n-gram graphs representation model!");
         }
     }
 }

--- a/src/main/java/org/scify/jedai/textmodels/GraphModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/GraphModel.java
@@ -74,9 +74,7 @@ public abstract class GraphModel extends AbstractModel {
                 }
                 return (float)(overallSimilarity / 2);
             default:
-                Log.error("The given similarity metric is incompatible with the n-gram graphs representation model!");
-                System.exit(-1);
-                return -1;
+            	throw new RuntimeException("The given similarity metric is incompatible with the n-gram graphs representation model!");
         }
     }
 }

--- a/src/main/java/org/scify/jedai/textmodels/TokenNGramsWithGlobalWeights.java
+++ b/src/main/java/org/scify/jedai/textmodels/TokenNGramsWithGlobalWeights.java
@@ -62,8 +62,7 @@ public class TokenNGramsWithGlobalWeights extends TokenNGrams {
                 similarity += 1.0f / (Math.log1p(((float) DOC_FREQ[DATASET_1].get(key)) * DOC_FREQ[DATASET_2].get(key)) / Math.log(2));
             }
         } else {
-            Log.error("Both models come from dataset 1!");
-            System.exit(-1);
+        	throw new RuntimeException("Both models come from dataset 1!");
         }
 
         return similarity;
@@ -118,9 +117,7 @@ public class TokenNGramsWithGlobalWeights extends TokenNGrams {
             case SIGMA_SIMILARITY:
                 return getSigmaSimilarity((TokenNGramsWithGlobalWeights) oModel);
             default:
-                Log.error("The given similarity metric is incompatible with the bag representation model!");
-                System.exit(-1);
-                return -1;
+            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/TokenNGramsWithGlobalWeights.java
+++ b/src/main/java/org/scify/jedai/textmodels/TokenNGramsWithGlobalWeights.java
@@ -62,7 +62,7 @@ public class TokenNGramsWithGlobalWeights extends TokenNGrams {
                 similarity += 1.0f / (Math.log1p(((float) DOC_FREQ[DATASET_1].get(key)) * DOC_FREQ[DATASET_2].get(key)) / Math.log(2));
             }
         } else {
-        	throw new RuntimeException("Both models come from dataset 1!");
+            throw new IllegalStateException("Both models come from dataset 1!");
         }
 
         return similarity;
@@ -117,7 +117,8 @@ public class TokenNGramsWithGlobalWeights extends TokenNGrams {
             case SIGMA_SIMILARITY:
                 return getSigmaSimilarity((TokenNGramsWithGlobalWeights) oModel);
             default:
-            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
+            throw new IllegalStateException(
+                    "The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/embeddings/PretrainedVectors.java
+++ b/src/main/java/org/scify/jedai/textmodels/embeddings/PretrainedVectors.java
@@ -6,7 +6,6 @@ import org.scify.jedai.utilities.enumerations.RepresentationModel;
 import org.scify.jedai.utilities.enumerations.SimilarityMetric;
 
 import java.io.BufferedReader;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
@@ -115,7 +114,7 @@ public abstract class PretrainedVectors extends VectorSpaceModel {
                dimension = Integer.parseInt(header[0]);
                dataSeparator = header[1].charAt(0);
            }catch (NumberFormatException ex){
-        	   throw new RuntimeException("Pretrained header malformed -- expected:<dimension>");
+                throw new RuntimeException("Pretrained header malformed -- expected:<dimension>", ex);
            }
            Log.info(String.format("Read dimension: [%d], delimiter: [%c]", dimension, dataSeparator));
            Log.info(String.format("Reading embedding mapping file. {%s}", Calendar.getInstance().getTime().toString()));
@@ -138,10 +137,8 @@ public abstract class PretrainedVectors extends VectorSpaceModel {
                elementMap.put(components[0], value);
            }
            Log.info(String.format("Done processing %d-line embedding mapping. {%s}",  counter, Calendar.getInstance().getTime().toString()));
-       } catch (FileNotFoundException e) {
-    	   throw new RuntimeException("No resource file found:" + fileName, e);
-       } catch (IOException e) {
-    	   throw new RuntimeException("IO exception when reading:" + fileName, e);
+        } catch (IOException e) {
+            throw new RuntimeException("Exception when reading: " + fileName, e);
        }
 
        unkownVector = getZeroVector();

--- a/src/main/java/org/scify/jedai/textmodels/embeddings/PretrainedVectors.java
+++ b/src/main/java/org/scify/jedai/textmodels/embeddings/PretrainedVectors.java
@@ -92,8 +92,7 @@ public abstract class PretrainedVectors extends VectorSpaceModel {
                 elementMap.put(components[0], value);
             }
         } catch (IOException e) {
-            Log.error("Problem loading embedding weights", e);
-            System.exit(-1);
+        	throw new RuntimeException("Problem loading embedding weights", e);
         }
     }
 
@@ -116,8 +115,7 @@ public abstract class PretrainedVectors extends VectorSpaceModel {
                dimension = Integer.parseInt(header[0]);
                dataSeparator = header[1].charAt(0);
            }catch (NumberFormatException ex){
-               Log.error("Pretrained header malformed -- expected:<dimension>");
-               System.exit(-1);
+        	   throw new RuntimeException("Pretrained header malformed -- expected:<dimension>");
            }
            Log.info(String.format("Read dimension: [%d], delimiter: [%c]", dimension, dataSeparator));
            Log.info(String.format("Reading embedding mapping file. {%s}", Calendar.getInstance().getTime().toString()));
@@ -141,11 +139,9 @@ public abstract class PretrainedVectors extends VectorSpaceModel {
            }
            Log.info(String.format("Done processing %d-line embedding mapping. {%s}",  counter, Calendar.getInstance().getTime().toString()));
        } catch (FileNotFoundException e) {
-           Log.error("No resource file found:" + fileName, e);
-           System.exit(-1);
+    	   throw new RuntimeException("No resource file found:" + fileName, e);
        } catch (IOException e) {
-           Log.error("IO exception when reading:" + fileName, e);
-           System.exit(-1);
+    	   throw new RuntimeException("IO exception when reading:" + fileName, e);
        }
 
        unkownVector = getZeroVector();

--- a/src/main/java/org/scify/jedai/textmodels/embeddings/VectorSpaceModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/embeddings/VectorSpaceModel.java
@@ -29,9 +29,7 @@ public abstract class VectorSpaceModel extends AbstractModel {
             case COSINE_SIMILARITY:
                 return getCosineSimilarity((VectorSpaceModel) oModel);
             default:
-                Log.error("The given similarity metric is incompatible with the bag representation model!");
-                System.exit(-1);
-                return -1;
+            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/textmodels/embeddings/VectorSpaceModel.java
+++ b/src/main/java/org/scify/jedai/textmodels/embeddings/VectorSpaceModel.java
@@ -1,6 +1,5 @@
 package org.scify.jedai.textmodels.embeddings;
 
-import com.esotericsoftware.minlog.Log;
 import org.scify.jedai.textmodels.AbstractModel;
 import org.scify.jedai.textmodels.ITextModel;
 import org.scify.jedai.utilities.enumerations.RepresentationModel;
@@ -29,7 +28,8 @@ public abstract class VectorSpaceModel extends AbstractModel {
             case COSINE_SIMILARITY:
                 return getCosineSimilarity((VectorSpaceModel) oModel);
             default:
-            	throw new RuntimeException("The given similarity metric is incompatible with the bag representation model!");
+                throw new IllegalStateException(
+                    "The given similarity metric is incompatible with the bag representation model!");
         }
     }
 

--- a/src/main/java/org/scify/jedai/utilities/TooManyComparisonsException.java
+++ b/src/main/java/org/scify/jedai/utilities/TooManyComparisonsException.java
@@ -1,0 +1,31 @@
+package org.scify.jedai.utilities;
+
+import static org.scify.jedai.utilities.IConstants.MAX_COMPARISONS;
+/**
+* Signals that the number of comparisons is excessively high. The maximum number of comparisons
+* allowed is specified by {@link IConstants#MAX_COMPARISONS}.
+*/
+
+public class TooManyComparisonsException extends RuntimeException {
+	private static final long serialVersionUID = -4822529736751878936L;
+
+	/**
+     * Constructs a new {@code TooManyComparisonsException} with an internally generated message as
+     * its detail message. The cause is not initialized, and may subsequently be initialized by a
+    * call to {@link #initCause}.
+     * 
+     * @param comparisonCount the number of requested comparisons. This number is expected to be
+     *     greater than {@link IConstants#MAX_COMPARISONS}.
+     */
+    public TooManyComparisonsException(long comparisonCount) {
+        super(formatMessage(comparisonCount));
+    }
+
+    /**
+     * Formats a string to be used as the detail message of the exception.
+     */
+    private static String formatMessage(long comparisonCount) {
+      return String.format("Requested number of comparisons [%,d] exceeds the maximum allowed "
+        + "limit [%,d].", comparisonCount, MAX_COMPARISONS);
+    }
+}

--- a/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
+++ b/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
@@ -50,9 +50,9 @@ public class OptimizeDirtyMoviesDataset {
 
     private final static int NO_OF_TRIALS = 100;
 
-    static float getTotalComparisons(List<AbstractBlock> blocks) {
-        long originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
+    static int getTotalComparisons(List<AbstractBlock> blocks) {
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
+++ b/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
@@ -51,8 +51,8 @@ public class OptimizeDirtyMoviesDataset {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        float originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Float::sum);
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
+++ b/src/test/java/org/scify/jedai/configuration/OptimizeDirtyMoviesDataset.java
@@ -51,8 +51,8 @@ public class OptimizeDirtyMoviesDataset {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        int originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
+        long originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
@@ -48,8 +48,8 @@ import org.scify.jedai.utilities.datastructures.BilateralDuplicatePropagation;
 public class StepByStepGridConfigurationCCER {
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        float originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Float::sum);
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
@@ -48,8 +48,8 @@ import org.scify.jedai.utilities.datastructures.BilateralDuplicatePropagation;
 public class StepByStepGridConfigurationCCER {
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        int originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
+        long originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationCCER.java
@@ -47,9 +47,9 @@ import org.scify.jedai.utilities.datastructures.BilateralDuplicatePropagation;
  */
 public class StepByStepGridConfigurationCCER {
 
-    static float getTotalComparisons(List<AbstractBlock> blocks) {
-        long originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
+    static int getTotalComparisons(List<AbstractBlock> blocks) {
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }
@@ -104,7 +104,7 @@ public class StepByStepGridConfigurationCCER {
             // local optimization of Block Building 
             float bestA = 0;
             int bestIteration = 0;
-            float originalComparisons = ((float) profiles1.size()) * profiles2.size();
+            int originalComparisons = profiles1.size() * profiles2.size();
             for (int j = 0; j < bb.getNumberOfGridConfigurations(); j++) {
                 bb.setNumberedGridConfiguration(j);
                 final List<AbstractBlock> originalBlocks = bb.getBlocks(profiles1, profiles2);

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
@@ -48,8 +48,8 @@ import java.util.List;
 public class StepByStepGridConfigurationDER {
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        float originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Float::sum);
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
@@ -48,8 +48,8 @@ import java.util.List;
 public class StepByStepGridConfigurationDER {
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        int originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
+        long originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepGridConfigurationDER.java
@@ -47,9 +47,9 @@ import java.util.List;
  */
 public class StepByStepGridConfigurationDER {
 
-    static float getTotalComparisons(List<AbstractBlock> blocks) {
-        long originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
+    static int getTotalComparisons(List<AbstractBlock> blocks) {
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }
@@ -89,7 +89,7 @@ public class StepByStepGridConfigurationDER {
             // local optimization of Block Building 
             float bestA = 0;
             int bestIteration = 0;
-            float originalComparisons = ((float) profiles.size()) * (profiles.size()-1.0f) / 2.0f;
+            int originalComparisons = profiles.size() * (profiles.size() - 1) / 2;
             for (int j = 0; j < bb.getNumberOfGridConfigurations(); j++) {
                 bb.setNumberedGridConfiguration(j);
                 final List<AbstractBlock> originalBlocks = bb.getBlocks(profiles);

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
@@ -50,8 +50,8 @@ public class StepByStepRandomConfigurationCCER {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        int originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
+        long originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
@@ -50,8 +50,8 @@ public class StepByStepRandomConfigurationCCER {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        float originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Float::sum);
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationCCER.java
@@ -49,9 +49,9 @@ public class StepByStepRandomConfigurationCCER {
 
     private final static int NO_OF_TRIALS = 100;
 
-    static float getTotalComparisons(List<AbstractBlock> blocks) {
-        long originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
+    static int getTotalComparisons(List<AbstractBlock> blocks) {
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }
@@ -106,7 +106,7 @@ public class StepByStepRandomConfigurationCCER {
             // local optimization of Block Building
             float bestA = 0;
             int bestIteration = 0;
-            float originalComparisons = ((float) profiles1.size()) * profiles2.size();
+            int originalComparisons = profiles1.size() * profiles2.size();
             for (int j = 0; j < NO_OF_TRIALS; j++) {
                 bb.setNextRandomConfiguration();
                 final List<AbstractBlock> originalBlocks = bb.getBlocks(profiles1, profiles2);

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
@@ -50,8 +50,8 @@ public class StepByStepRandomConfigurationDER {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        float originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Float::sum);
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
@@ -50,8 +50,8 @@ public class StepByStepRandomConfigurationDER {
     private final static int NO_OF_TRIALS = 100;
 
     static float getTotalComparisons(List<AbstractBlock> blocks) {
-        int originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
+        long originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }

--- a/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
+++ b/src/test/java/org/scify/jedai/configuration/StepByStepRandomConfigurationDER.java
@@ -49,9 +49,9 @@ public class StepByStepRandomConfigurationDER {
 
     private final static int NO_OF_TRIALS = 100;
 
-    static float getTotalComparisons(List<AbstractBlock> blocks) {
-        long originalComparisons = 0;
-        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Long::sum);
+    static int getTotalComparisons(List<AbstractBlock> blocks) {
+        int originalComparisons = 0;
+        originalComparisons = blocks.stream().map(AbstractBlock::getNoOfComparisons).reduce(originalComparisons, Integer::sum);
         System.out.println("Original comparisons\t:\t" + originalComparisons);
         return originalComparisons;
     }
@@ -93,7 +93,7 @@ public class StepByStepRandomConfigurationDER {
             // local optimization of Block Building
             float bestA = 0;
             int bestIteration = 0;
-            float originalComparisons = ((float) profiles.size()) * (profiles.size() - 1.0f) / 2.0f;
+            int originalComparisons = profiles.size() * (profiles.size() - 1) / 2;
             for (int j = 0; j < NO_OF_TRIALS; j++) {
                 bb.setNextRandomConfiguration();
                 final List<AbstractBlock> originalBlocks = bb.getBlocks(profiles);


### PR DESCRIPTION
Next to changing the comparison counts type to int I have also made changes to throw exceptions instead of the `System.exit(1)`s. 
Using exceptions improves the usability of the jedai-core library by other projects. Using `System.exit(1)` terminates the calling process, where using exceptions enables the caller to handle the exception according to its own workflows. 